### PR TITLE
Fix throwing ArrayIndexOutOfBoundsException bug

### DIFF
--- a/src/main/java/com/maroontress/intexpr/impl/Compiler.java
+++ b/src/main/java/com/maroontress/intexpr/impl/Compiler.java
@@ -95,8 +95,8 @@ public final class Compiler {
         return (c, token) -> {
             var maybeOperator = Operator.of(token, type);
             if (maybeOperator.isEmpty()) {
-                throw new IllegalArgumentException(
-                        Messages.of(token, "unknown operator"));
+                var m = Messages.of(token, "unknown " + type + " operator");
+                throw new IllegalArgumentException(m);
             }
             c.pushOperator(maybeOperator.get());
         };

--- a/src/main/java/com/maroontress/intexpr/impl/IntBinaryOperation.java
+++ b/src/main/java/com/maroontress/intexpr/impl/IntBinaryOperation.java
@@ -19,6 +19,10 @@ public interface IntBinaryOperation extends Operation {
     @Override
     default Executable toExecutable() {
         return (s, n, t) -> {
+            if (n < 2) {
+                var m = Messages.of(t, "operand is missing");
+                throw new IllegalArgumentException(m);
+            }
             var k = n - 1;
             var left = s[k - 1];
             var right = s[k];

--- a/src/main/java/com/maroontress/intexpr/impl/IntUnaryOperation.java
+++ b/src/main/java/com/maroontress/intexpr/impl/IntUnaryOperation.java
@@ -18,6 +18,10 @@ public interface IntUnaryOperation extends Operation {
     @Override
     default Executable toExecutable() {
         return (s, n, t) -> {
+            if (n < 1) {
+                var m = Messages.of(t, "operand is missing");
+                throw new IllegalArgumentException(m);
+            }
             var k = n - 1;
             var operand = s[k];
             s[k] = Operations.perform(t, () -> apply(operand));

--- a/src/main/java/com/maroontress/intexpr/impl/Operator.java
+++ b/src/main/java/com/maroontress/intexpr/impl/Operator.java
@@ -43,6 +43,10 @@ public final class Operator implements Instruction {
         return spec;
     }
 
+    public Token getToken() {
+        return token;
+    }
+
     /** {@inheritDoc} */
     @Override
     public void accept(Deque<SyntaxNode> stack) {

--- a/src/main/java/com/maroontress/intexpr/impl/PendedOperator.java
+++ b/src/main/java/com/maroontress/intexpr/impl/PendedOperator.java
@@ -86,7 +86,7 @@ public interface PendedOperator {
 
             @Override
             public Token getToken() {
-                throw new IllegalStateException();
+                return operator.getToken();
             }
         };
     }

--- a/src/test/java/com/maroontress/intexpr/IntExprTest.java
+++ b/src/test/java/com/maroontress/intexpr/IntExprTest.java
@@ -298,4 +298,56 @@ public final class IntExprTest {
         }
         throw new AssertionError();
     }
+
+    @Test
+    public void noRightOperandWithBinaryOperator() {
+        var expr = "1+";
+        //          12
+        try {
+            IntExpr.eval(expr);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("L1:2: operand is missing: \"+\""));
+            return;
+        }
+        throw new AssertionError();
+    }
+
+    @Test
+    public void noOperandWithUnaryOperator() {
+        var expr = "-";
+        //          1
+        try {
+            IntExpr.eval(expr);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("L1:1: operand is missing: \"-\""));
+            return;
+        }
+        throw new AssertionError();
+    }
+
+    @Test
+    public void unknownUnaryOperator() {
+        var expr = "*";
+        //          1
+        try {
+            IntExpr.eval(expr);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("L1:1: unknown UNARY operator: \"*\""));
+            return;
+        }
+        throw new AssertionError();
+    }
+
+    @Test
+    public void unknownBinaryOperator() {
+        var expr = "1!";
+        //          12
+        try {
+            IntExpr.eval(expr);
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("L1:2: unknown BINARY operator: \"!\""));
+            return;
+        }
+        throw new AssertionError();
+    }
 }


### PR DESCRIPTION
- Fixed an issue where IntExpr.eval(String) would throw ArrayIndexOutOfBoundsException for expressions like:
  - Binary operators missing right-hand operand (e.g., "1+")
  - Unary operators missing operand (e.g., "-")
- Modify the exception detail message to include whether the operator is unary or binary when an unknown operator is detected
- Add test cases